### PR TITLE
Refactor contexts and allow multiple contexts to be passed

### DIFF
--- a/docs/searches/contexts.md
+++ b/docs/searches/contexts.md
@@ -23,6 +23,23 @@ ArticleSearch.context(:public, :blog)
 ArticleSearch.context(:public).context(:blog)
 ```
 
+Current context can used to alter search queries or filters:
+
+```ruby
+class ArticleSearch < Caoutsearch::Search::Base
+  has_context :public do
+    filters << { term: { published: true } }
+  end
+
+  match_all do |value|
+    targets = %w[title body]
+    targets << "author" unless current_context?(:public)
+
+    filter_by(targets, value)
+  end
+end
+```
+
 Missing contexts doesn't raise an expection and are ignored.
 It allows you to apply contexts to any searches, whether the context is implemented or not:
 

--- a/docs/searches/contexts.md
+++ b/docs/searches/contexts.md
@@ -1,4 +1,42 @@
 ---
-title: "[TODO] Contexts"
+title: Contexts
 order: -5
 ---
+
+Contexts allows to create search scopes independently of search criteria.
+Because search criteria may comes from user inputs, contexts offers a way to force search scoping :
+
+```ruby
+class ArticleSearch < Caoutsearch::Search::Base
+  has_context :public do
+    filters << { term: { published: true } }
+  end
+end
+
+ArticleSearch.context(:public).search(params[:q])
+```
+
+Multiple contexts can be passed together or chained:
+
+```ruby
+ArticleSearch.context(:public, :blog)
+ArticleSearch.context(:public).context(:blog)
+```
+
+Missing contexts doesn't raise an expection and are ignored.
+It allows you to apply contexts to any searches, whether the context is implemented or not:
+
+```ruby
+class BlogController < ApplicationController
+  def index
+    @articles = ArticleSearch.context(current_context).search(params[:q])
+    @tags = TagSearch.context(current_context).search(params[:q]) # TagSearch doesn't implement a "public" context
+  end
+
+  protected
+
+  def current_context
+    :public unless current_user&.admin?
+  end
+end
+```

--- a/lib/caoutsearch/search/inspect.rb
+++ b/lib/caoutsearch/search/inspect.rb
@@ -5,7 +5,7 @@ module Caoutsearch
     module Inspect
       PROPERTIES_TO_INSPECT = %i[
         search_criteria
-        current_context
+        current_contexts
         current_order
         current_page
         current_limit

--- a/lib/caoutsearch/search/internal_dsl.rb
+++ b/lib/caoutsearch/search/internal_dsl.rb
@@ -15,13 +15,13 @@ module Caoutsearch
         #   self.config[:filter][key] = ...
         #
         class_attribute :config, default: {
-          contexts: ActiveSupport::HashWithIndifferentAccess.new,
           filters: ActiveSupport::HashWithIndifferentAccess.new,
           defaults: ActiveSupport::HashWithIndifferentAccess.new,
           suggestions: ActiveSupport::HashWithIndifferentAccess.new,
           sorts: ActiveSupport::HashWithIndifferentAccess.new
         }
 
+        class_attribute :contexts, instance_accessor: false, default: {}
         class_attribute :aggregations, instance_accessor: false, default: {}
         class_attribute :transformations, instance_accessor: false, default: {}
       end
@@ -32,7 +32,7 @@ module Caoutsearch
           config[:match_all] = block
         end
 
-        %w[context default].each do |method|
+        %w[default].each do |method|
           config_attribute = method.pluralize.to_sym
 
           define_method method do |name = nil, &block|
@@ -66,6 +66,11 @@ module Caoutsearch
 
         def alias_sort(new_name, old_name)
           sort(new_name) { |direction| sort_by(old_name, direction) }
+        end
+
+        def has_context(name, &block)
+          self.contexts = contexts.dup
+          contexts[name.to_s] = Caoutsearch::Search::DSL::Item.new(name, &block)
         end
 
         def has_aggregation(name, definition = {}, &block)

--- a/lib/caoutsearch/search/query_builder.rb
+++ b/lib/caoutsearch/search/query_builder.rb
@@ -5,6 +5,7 @@ module Caoutsearch
     module QueryBuilder
       extend ActiveSupport::Concern
       include QueryBuilder::Aggregations
+      include QueryBuilder::Contexts
 
       def build
         reset_variable(:@elasticsearch_query)
@@ -13,7 +14,7 @@ module Caoutsearch
         run_callbacks :build do
           build_prepend_hash
           build_search_criteria
-          build_context
+          build_contexts
           build_defaults
           build_limits
           build_orders
@@ -33,13 +34,6 @@ module Caoutsearch
 
       def build_search_criteria
         search_by(search_criteria)
-      end
-
-      def build_context
-        return unless current_context
-
-        item = config[:contexts][current_context.to_s]
-        instance_exec(&item.block) if item
       end
 
       def build_defaults

--- a/lib/caoutsearch/search/query_builder/contexts.rb
+++ b/lib/caoutsearch/search/query_builder/contexts.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Caoutsearch
+  module Search
+    module QueryBuilder
+      module Contexts
+        private
+
+        def build_contexts
+          call_contexts(*current_contexts) if current_contexts
+        end
+
+        def call_contexts(*args)
+          args.each do |arg|
+            call_context(arg)
+          end
+        end
+
+        def call_context(name)
+          name = name.to_s
+
+          if self.class.contexts.include?(name)
+            item = self.class.contexts[name]
+            call_context_item(item)
+          end
+        end
+
+        def call_context_item(item)
+          instance_exec(&item.block)
+        end
+      end
+    end
+  end
+end

--- a/lib/caoutsearch/search/search_methods.rb
+++ b/lib/caoutsearch/search/search_methods.rb
@@ -5,7 +5,7 @@ module Caoutsearch
     module SearchMethods
       extend ActiveSupport::Concern
 
-      attr_reader :current_context, :current_order, :current_aggregations,
+      attr_reader :current_contexts, :current_order, :current_aggregations,
         :current_suggestions, :current_fields, :current_source
 
       # Public API
@@ -97,8 +97,9 @@ module Caoutsearch
         self
       end
 
-      def context!(value)
-        @current_context = value
+      def context!(*values)
+        @current_contexts ||= []
+        @current_contexts += values.flatten
         self
       end
 
@@ -173,7 +174,7 @@ module Caoutsearch
         "aggregations"    => :@current_aggregations,
         "suggest"         => :@current_suggestions,
         "suggestions"     => :@current_suggestions,
-        "context"         => :@current_context,
+        "context"         => :@current_contexts,
         "order"           => :@current_order,
         "page"            => :@current_page,
         "offset"          => :@current_offset,

--- a/lib/caoutsearch/search/search_methods.rb
+++ b/lib/caoutsearch/search/search_methods.rb
@@ -190,7 +190,7 @@ module Caoutsearch
         self
       end
 
-      # Getters
+      # Getters and predicates
       # ------------------------------------------------------------------------
       def search_criteria
         @search_criteria ||= []
@@ -212,6 +212,10 @@ module Caoutsearch
         else
           0
         end
+      end
+
+      def current_context?(name)
+        @current_contexts&.map(&:to_s)&.include?(name.to_s)
       end
 
       # Criteria handlers

--- a/spec/caoutsearch/search/query_builder/contexts_spec.rb
+++ b/spec/caoutsearch/search/query_builder/contexts_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Caoutsearch::Search::QueryBuilder::Contexts do
+  let!(:search_class) do
+    stub_search_class("SampleSearch") do
+      has_context :public do
+        filters << {term: {published: true}}
+      end
+
+      has_context :blog do
+        filters << {term: {destination: "blog"}}
+      end
+    end
+  end
+
+  it "applies one context to a query" do
+    search = search_class.new.context(:public)
+
+    expect(search.build).to eq(
+      query: {
+        bool: {
+          filter: [
+            {term: {published: true}}
+          ]
+        }
+      }
+    )
+  end
+
+  it "builds a query with multiple contexts" do
+    search = search_class.new.context(:public, :blog)
+
+    expect(search.build).to eq(
+      query: {
+        bool: {
+          filter: [
+            {term: {published: true}},
+            {term: {destination: "blog"}}
+          ]
+        }
+      }
+    )
+  end
+
+  it "ignores missing contexts" do
+    search = search_class.new.context(:public, :api)
+
+    expect(search.build).to eq(
+      query: {
+        bool: {
+          filter: [
+            {term: {published: true}}
+          ]
+        }
+      }
+    )
+  end
+end

--- a/spec/caoutsearch/search/search_methods_spec.rb
+++ b/spec/caoutsearch/search/search_methods_spec.rb
@@ -5,21 +5,43 @@ require "spec_helper"
 RSpec.describe Caoutsearch::Search::SearchMethods do
   let!(:search_class) { stub_search_class("SampleSearch") }
 
-  it "chains search aggregations" do
-    search = search_class.new.aggregate(:tags).aggregate(:views)
+  describe "#context" do
+    it "registers a search context" do
+      search = search_class.new.context(:public)
 
-    expect(search).to have_attributes(current_aggregations: [:tags, :views])
+      expect(search).to have_attributes(current_contexts: [:public])
+    end
+
+    it "chains search contexts" do
+      search = search_class.new.context(:public).context(:api)
+
+      expect(search).to have_attributes(current_contexts: [:public, :api])
+    end
+
+    it "combines multiple contexts" do
+      search = search_class.new.context(:public, :api)
+
+      expect(search).to have_attributes(current_contexts: [:public, :api])
+    end
   end
 
-  it "combines multiple aggregations" do
-    search = search_class.new.aggregate(:tags, :views)
+  describe "#aggregate" do
+    it "chains search aggregations" do
+      search = search_class.new.aggregate(:tags).aggregate(:views)
 
-    expect(search).to have_attributes(current_aggregations: [:tags, :views])
-  end
+      expect(search).to have_attributes(current_aggregations: [:tags, :views])
+    end
 
-  it "combines multiple aggregations with arguments" do
-    search = search_class.new.aggregate(tags: 20)
+    it "combines multiple aggregations" do
+      search = search_class.new.aggregate(:tags, :views)
 
-    expect(search).to have_attributes(current_aggregations: [{tags: 20}])
+      expect(search).to have_attributes(current_aggregations: [:tags, :views])
+    end
+
+    it "combines multiple aggregations with arguments" do
+      search = search_class.new.aggregate(tags: 20)
+
+      expect(search).to have_attributes(current_aggregations: [{tags: 20}])
+    end
   end
 end

--- a/spec/caoutsearch/search/search_methods_spec.rb
+++ b/spec/caoutsearch/search/search_methods_spec.rb
@@ -25,6 +25,34 @@ RSpec.describe Caoutsearch::Search::SearchMethods do
     end
   end
 
+  describe "#context?" do
+    it "checks what contexts are included" do
+      search = search_class.new.context(:public)
+
+      aggregate_failures do
+        expect(search).to be_current_context(:public)
+        expect(search).not_to be_current_context(:blog)
+      end
+    end
+
+    it "checks a context is included, not matter it's a String or a Symbol" do
+      search = search_class.new.context(:public).context("api")
+
+      aggregate_failures do
+        expect(search).to be_current_context("public")
+        expect(search).to be_current_context(:api)
+      end
+    end
+
+    it "checks what contexts are included, even when no context esists" do
+      search = search_class.new
+
+      aggregate_failures do
+        expect(search).not_to be_current_context(:public)
+      end
+    end
+  end
+
   describe "#aggregate" do
     it "chains search aggregations" do
       search = search_class.new.aggregate(:tags).aggregate(:views)


### PR DESCRIPTION
## What's included in this PR ?

- [x] refactor internal implementation of contexts
- [x] allow to pass multiple contexts
- [x] add specs and documentation about contexts


## What's added in the documentation ?

Contexts allows to create search scopes independently of search criteria.
Because search criteria may comess from user inputs, contexts offers a way to force search scoping :

```ruby
class ArticleSearch < Caoutsearch::Search::Base
  has_context :public do
    filters << { term: { published: true } }
  end
end

ArticleSearch.context(:public).search(params[:q])
```

Multiple contexts can be passed together or chained:

```ruby
ArticleSearch.context(:public, :blog)
ArticleSearch.context(:public).context(:blog)
```

Missing contexts doesn't raise an expection and are ignored.
It allows you to apply contexts to any searches, whether the context is implemented or not:

```ruby
class BlogController < ApplicationController
  def index
    @articles = ArticleSearch.context(current_context).search(params[:q])
    @tags = TagSearch.context(current_context).search(params[:q]) # TagSearch doesn't implement a "public" context
  end

  protected

  def current_context
    :public unless current_user&.admin?
  end
end
```
